### PR TITLE
Add mobile-friendly AI prompt interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AI Prompt Interface</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 1rem;
+      max-width: 600px;
+      margin-left: auto;
+      margin-right: auto;
+      line-height: 1.5;
+    }
+
+    h1 {
+      font-size: 1.8rem;
+      text-align: center;
+      margin-bottom: 1rem;
+    }
+
+    textarea {
+      width: 100%;
+      height: 150px;
+      font-size: 1.2rem;
+      padding: 0.5rem;
+      box-sizing: border-box;
+      border-radius: 4px;
+      border: 1px solid #ccc;
+    }
+
+    button {
+      width: 100%;
+      padding: 1rem;
+      font-size: 1.2rem;
+      margin-top: 1rem;
+      border: none;
+      border-radius: 4px;
+      background-color: #007bff;
+      color: #fff;
+    }
+
+    button:active {
+      background-color: #0056b3;
+    }
+
+    #result {
+      margin-top: 1rem;
+      font-size: 1.2rem;
+      white-space: pre-wrap;
+    }
+  </style>
+</head>
+<body>
+  <h1>AI Prompt Interface</h1>
+  <textarea id="prompt" placeholder="Enter your prompt here..."></textarea>
+  <button id="send">Send Prompt</button>
+  <div id="result"></div>
+
+  <script>
+    // Update this endpoint to your AI API
+    const API_ENDPOINT = 'https://api.example.com/v1/generate';
+
+    // Insert your API key or other headers as needed
+    // const API_KEY = 'YOUR_API_KEY_HERE';
+
+    document.getElementById('send').addEventListener('click', async () => {
+      const prompt = document.getElementById('prompt').value.trim();
+      const result = document.getElementById('result');
+
+      if (!prompt) {
+        result.textContent = 'Please enter a prompt.';
+        return;
+      }
+
+      result.textContent = 'Loading...';
+
+      try {
+        const response = await fetch(API_ENDPOINT, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            // 'Authorization': `Bearer ${API_KEY}` // Un-comment and set API_KEY if required
+          },
+          body: JSON.stringify({ prompt })
+        });
+
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+
+        const data = await response.json();
+        result.textContent = data.response || 'No response field found.';
+      } catch (err) {
+        result.textContent = `Error: ${err.message}`;
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add responsive HTML page for sending prompts to a configurable AI API
- Include in-page JavaScript for fetch handling, loading state, and errors

## Testing
- `npx -y htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68a18cafd064832faa3a1e15a9d17eae